### PR TITLE
changed definition of clock_gettime

### DIFF
--- a/util_pkt_logger/src/util_pkt_logger.c
+++ b/util_pkt_logger/src/util_pkt_logger.c
@@ -83,11 +83,9 @@ void usage (void);
  * production but for testing only. */
 
 #ifdef __MACH__
-#define CLOCK_REALTIME 0
-#define CLOCK_MONOTONIC 0
 #include <sys/time.h>
 
-static int clock_gettime(int clk_id, struct timespec* t) {
+int clock_gettime(clockid_t clk_id, struct timespec* t) {
 	(void) clk_id;
 	struct timeval now;
     int rv = gettimeofday(&now, NULL);


### PR DESCRIPTION
On macOS, build of the `util_pkt_logger` fails because of an incorrect redefinition of the function `static int clock_gettime()`. Indeed, the function is already in the `sys/time.h` header, but as `int clock_gettime(clockid_t clk_id, struct timespec* t)` - which doesn't match.

This is the exact error:

```
$ make all
/Applications/Xcode.app/Contents/Developer/usr/bin/make all -e -C util_pkt_logger
mkdir -p obj
gcc -c -O2 -Wall -Wextra -std=c99 -Iinc -I. -I../libloragw/inc src/util_pkt_logger.c -o obj/util_pkt_logger.o
src/util_pkt_logger.c:86:9: warning: 'CLOCK_REALTIME' macro redefined [-Wmacro-redefined]
#define CLOCK_REALTIME 0
        ^
/usr/include/time.h:154:9: note: previous definition is here
#define CLOCK_REALTIME _CLOCK_REALTIME
        ^
src/util_pkt_logger.c:87:9: warning: 'CLOCK_MONOTONIC' macro redefined [-Wmacro-redefined]
#define CLOCK_MONOTONIC 0
        ^
/usr/include/time.h:156:9: note: previous definition is here
#define CLOCK_MONOTONIC _CLOCK_MONOTONIC
        ^
src/util_pkt_logger.c:90:12: error: static declaration of 'clock_gettime' follows non-static declaration
static int clock_gettime(int clk_id, struct timespec* t) {
           ^
/usr/include/time.h:177:5: note: previous declaration is here
int clock_gettime(clockid_t __clock_id, struct timespec *__tp);
    ^
2 warnings and 1 error generated.
make[1]: *** [obj/util_pkt_logger.o] Error 1
make: *** [all] Error 2
```

These changes don't affect build on other platforms.